### PR TITLE
Updated Legend and Background Map

### DIFF
--- a/src/hexbin-layer.js
+++ b/src/hexbin-layer.js
@@ -12,8 +12,8 @@ L.HexbinLayer = L.Layer.extend({
 		radius: 25,
 		opacity: 0.6,
 		duration: 200,
-		valueDomain: [20, 40, 60, 90, 200, 500],
-		colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00', '#960084', '#001996'],
+		valueDomain: [20, 40, 60, 100, 500],
+		colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00', '#960084'],
 
 		onmouseover: undefined,
 		onmouseout: undefined,

--- a/src/legend.vue
+++ b/src/legend.vue
@@ -48,7 +48,7 @@ colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00'],*/
 	height 200px
 	display flex
 	.gradient
-		opacity 0.6
+		opacity 0.8
 		width 20px
 		background linear-gradient(to top, rgba(0,121,107,1) 0%, rgba(0,121,107,1) 16%, rgba(249,168,37,1) 32%, rgba(230,81,0,1) 48%, rgba(221,44,0,1) 72%, rgba(221,44,0,1) 80%, rgba(140,0,132,1) 100%)
 		position relative

--- a/src/legend.vue
+++ b/src/legend.vue
@@ -5,11 +5,10 @@
 			.limit
 		.labels
 			.label(style="bottom: 100%") 500
-			.label(style="bottom: 75%") 200
-			.label(style="bottom: 50%") 100
-			.label(style="bottom: 37.5%") 75
-			.label.limit(style="bottom: 25%") 50
-			.label(style="bottom: 12.5%") 25
+			.label(style="bottom: 80%") 100
+			.label(style="bottom: 60%") 75
+			.label.limit(style="bottom: 40%") 50
+			.label(style="bottom: 20%") 25
 			.label(style="bottom: 0%") 0 µg/m³
 </template>
 <script>
@@ -51,7 +50,7 @@ colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00'],*/
 	.gradient
 		opacity 0.6
 		width 20px
-		background linear-gradient(to top, rgba(0,121,107,1) 0%, rgba(0,121,107,1) 10%, rgba(249,168,37,1) 20%, rgba(230,81,0,1) 30%, rgba(221,44,0,1) 45%, rgba(221,44,0,1) 50%, rgba(96,0,84,1) 75%, rgba(0,19,96,1) 100%)
+		background linear-gradient(to top, rgba(0,121,107,1) 0%, rgba(0,121,107,1) 16%, rgba(249,168,37,1) 32%, rgba(230,81,0,1) 48%, rgba(221,44,0,1) 72%, rgba(221,44,0,1) 80%, rgba(140,0,132,1) 100%)
 		position relative
 		.limit
 			height 2px
@@ -59,7 +58,7 @@ colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00'],*/
 			background-color $clr-red-a700
 			position absolute
 			left -10px
-			bottom calc(25% - 1px)
+			bottom calc(40% - 1px)
 	.labels
 		width 150px
 		position relative

--- a/src/style.styl
+++ b/src/style.styl
@@ -56,3 +56,7 @@ body, #content
 	z-index 500
 	font-weight 200
 	text-align right
+
+img.leaflet-tile 
+	filter: grayscale(90%) contrast(90%) brightness(110%);
+ 

--- a/src/style.styl
+++ b/src/style.styl
@@ -58,5 +58,5 @@ body, #content
 	text-align right
 
 img.leaflet-tile 
-	filter: grayscale(90%) contrast(90%) brightness(110%);
+	filter: grayscale(85%) saturate(150%) hue-rotate(60deg) contrast(90%) brightness(110%);
  


### PR DESCRIPTION
* Updated Legend to show values from 0-500, but 0-100 takes 80% of the Space
* Some CSS Colorfilters for the OSM maptiles, inspired by https://michaelkreil.github.io/feinstaub-map/ by @michaelkreil