### PR TITLE
use always TLS for tiles to avoid mixed content

### DIFF
--- a/src/map.vue
+++ b/src/map.vue
@@ -15,8 +15,8 @@ export default {
 				center: config.center,
 				zoom: 11
 			})
-			leaflet.tileLayer('http://{s}.tiles.madavi.de/{z}/{x}/{y}.png', {
-				attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+			leaflet.tileLayer('https://{s}.tiles.madavi.de/{z}/{x}/{y}.png', {
+				attribution: 'Map data © <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
 				maxZoom: 13,
 				// continuousWorld: false,
 				// noWrap: true


### PR DESCRIPTION
If you use the browser extension https-everywhere and open the demo page, you will use the TLS url for github.io.
TLS is available for tiles and github.io so let's encrypt?