### PR TITLE
show AQI instead of particle weight

### DIFF
--- a/src/cell-info.vue
+++ b/src/cell-info.vue
@@ -16,10 +16,12 @@
 			th Sensor ID
 			th PM10 µg/m³
 			th PM2.5 µg/m³
+			th AQI
 		tr.mean
 			td mean
 			td {{mean.P1.toFixed(0)}}
 			td {{mean.P2.toFixed(0)}}
+			td {{mean.AQI.toFixed(0)}}
 		template(v-for="sensor in cell")
 			tr
 				td(style="text-align:left;")
@@ -27,6 +29,7 @@
 					a(:id="'graph_'+sensor.o.id+'_off'" class="graph_off" onclick="var sensor=this.id.substring(0,this.id.length-4);document.getElementById(sensor).style.display='none';document.getElementById(sensor+'_on').style.display='';document.getElementById(sensor+'_off').style.display='none'; document.getElementById('images_'+sensor.substr(6)).innerHTML=''; return false;" href='#' style='color:white; text-decoration: none; display: none;') (-)&nbsp;{{sensor.o.id}}
 				td {{sensor.o.data.P1.toFixed(0)}}
 				td {{sensor.o.data.P2.toFixed(0)}}
+				td {{sensor.o.data.AQI.toFixed(0)}}
 			tr(:id = "'graph_'+sensor.o.id" style="display:none" class="cell_info_images")
 				td(:id = "'images_'+sensor.o.id" colspan='3')
 					br
@@ -46,7 +49,8 @@ export default {
 		mean () {
 			return {
 				P1: _.meanBy(this.cell, (o) => o.o.data.P1),
-				P2: _.meanBy(this.cell, (o) => o.o.data.P2)
+				P2: _.meanBy(this.cell, (o) => o.o.data.P2),
+				AQI: _.meanBy(this.cell, (o) => o.o.data.AQI)
 			}
 		}
 	}

--- a/src/feinstaub-api.js
+++ b/src/feinstaub-api.js
@@ -8,7 +8,7 @@ const AQI=[50,100,150,200,300,400,500,1000];
 const AQI_PM10=[54,154,254,354,424,504,604,99999];
 const AQI_PM25=[12,35.4,55.4,150.4,250.4,350.4,500.4,99999.9];
 
-function get_aqi(value, scale) {
+function rescaleValue(value, scale) {
 	var v0 = 0;
 	var s0 = 0;
 	for (var i in scale) {
@@ -24,11 +24,10 @@ function get_aqi(value, scale) {
 	return s0 + ( (value - v0) * de_v ) 
 }
 
-function get_AQI(pm10, pm25) {
-	var r = Math.max(get_aqi(pm10, AQI_PM10), get_aqi(pm25, AQI_PM25));
+function getAQI(pm10, pm25) {
+	var r = Math.max(rescaleValue(pm10, AQI_PM10), rescaleValue(pm25, AQI_PM25));
 	return r
 }
-
 
 let api = {
 	fetchNow() {
@@ -75,7 +74,7 @@ let api = {
 						data: {
 							P1: P1,
 							P2: P2,
-							AQI: get_AQI(P1, P2)
+							AQI: getAQI(P1, P2)
 						}
 					}
 				})

--- a/src/feinstaub-api.js
+++ b/src/feinstaub-api.js
@@ -4,6 +4,32 @@ const URL = 'https://api.luftdaten.info/static/v2/data.dust.min.json'
 import _ from 'lodash'
 import 'whatwg-fetch'
 
+const AQI=[50,100,150,200,300,400,500,1000];
+const AQI_PM10=[54,154,254,354,424,504,604,99999];
+const AQI_PM25=[12,35.4,55.4,150.4,250.4,350.4,500.4,99999.9];
+
+function get_aqi(value, scale) {
+	var v0 = 0;
+	var s0 = 0;
+	for (var i in scale) {
+		var v1 = scale[i]
+		var s1 = AQI[i]
+		var delta_v = v1 - v0
+		var delta_s = s1 - s0
+		if (v0 <= value <= v1) {
+		  var de_v = delta_s / delta_v
+		  return  s0 + ( (value - v0) * de_v )}
+		s0 = s1
+		v0 = v1}
+	return s0 + ( (value - v0) * de_v ) 
+}
+
+function get_AQI(pm10, pm25) {
+	var r = Math.max(get_aqi(pm10, AQI_PM10), get_aqi(pm25, AQI_PM25));
+	return r
+}
+
+
 let api = {
 	fetchNow() {
 		return fetch(URL).then((response) => response.json())
@@ -40,13 +66,16 @@ let api = {
 						}
 						return acc
 					}, {P1: 0, P2: 0})
+					var P1 = data.P1 / values.length;
+					var P2 = data.P2 / values.length
 					return {
 						latitude: lat,
 						longitude: long,
 						id: values[0].sensor.id,
 						data: {
-							P1: data.P1 / values.length,
-							P2: data.P2 / values.length
+							P1: P1,
+							P2: P2,
+							AQI: get_AQI(P1, P2)
 						}
 					}
 				})

--- a/src/hexbin-layer.js
+++ b/src/hexbin-layer.js
@@ -14,8 +14,8 @@ L.HexbinLayer = L.Layer.extend({
 		radius: 25,
 		opacity: 0.6,
 		duration: 200,
-		valueDomain: [20, 40, 60, 100, 500],
-		colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00', '#960084'],
+		valueDomain: [0, 50, 100, 150, 200, 9999],
+		colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00', '#960084', '#000000'],
 
 		onmouseover: undefined,
 		onmouseout: undefined,

--- a/src/hexbin-layer.js
+++ b/src/hexbin-layer.js
@@ -6,6 +6,8 @@ import _ from 'lodash'
 
 d3.hexbin = d3Hexbin.hexbin
 
+
+
 L.HexbinLayer = L.Layer.extend({
 	_undef (a) { return typeof a === 'undefined' },
 	options: {
@@ -25,7 +27,7 @@ L.HexbinLayer = L.Layer.extend({
 			return d.latitude
 		},
 		value: function (d) {
-			return _.meanBy(d, (o) => o.o.data.P1)
+			return _.meanBy(d, (o) => o.o.data.AQI)
 		}
 	},
 

--- a/src/legend.vue
+++ b/src/legend.vue
@@ -9,7 +9,7 @@
 			.label(style="bottom: 60%") 75
 			.label.limit(style="bottom: 40%") 50
 			.label(style="bottom: 20%") 25
-			.label(style="bottom: 0%") 0 µg/m³
+			.label(style="bottom: 0%") 0 AQI
 </template>
 <script>
 export default {

--- a/src/legend.vue
+++ b/src/legend.vue
@@ -4,11 +4,11 @@
 		.gradient
 			.limit
 		.labels
-			.label(style="bottom: 100%") 500
-			.label(style="bottom: 80%") 100
-			.label(style="bottom: 60%") 75
-			.label.limit(style="bottom: 40%") 50
-			.label(style="bottom: 20%") 25
+			.label(style="bottom: 100%") 10000
+			.label(style="bottom: 80%") 200
+			.label(style="bottom: 60%") 150
+			.label.limit(style="bottom: 40%") 100
+			.label(style="bottom: 20%") 50
 			.label(style="bottom: 0%") 0 AQI
 </template>
 <script>
@@ -50,7 +50,7 @@ colorRange: ['#00796B', '#F9A825', '#E65100', '#DD2C00'],*/
 	.gradient
 		opacity 0.8
 		width 20px
-		background linear-gradient(to top, rgba(0,121,107,1) 0%, rgba(0,121,107,1) 16%, rgba(249,168,37,1) 32%, rgba(230,81,0,1) 48%, rgba(221,44,0,1) 72%, rgba(221,44,0,1) 80%, rgba(140,0,132,1) 100%)
+		background linear-gradient(to top, rgba(0,121,107,1) 0%, rgba(249,168,37,1) 20%, rgba(230,81,0,1) 40%, rgba(221,44,0,1) 60%, rgba(140,0,132,1) 80%, rgba(1,1,1,1) 100%)
 		position relative
 		.limit
 			height 2px


### PR DESCRIPTION
This uses both PM10 and PM25 data to compute AQI index, which is used to color the map
~~The scale colors are not adapted yet.~~
Could be a fix for https://github.com/opendata-stuttgart/feinstaub-map/issues/5
You can check this version ~~[here](https://ipfs.io/ipfs/QmcVMUJD1Gjtmgpmk9ZPhjSGc7YoeJsjPY2B8CfqBkeMyE)~~  [here](https://ipfs.io/ipfs/QmX4WvGi1QbatLULuu2sDYLjmn6TvcJd3EgfK8TBtAtd97) (updated with scale)

Not really strong in js. I'm even surprised I made it work
AQI breakpoints from: https://aqs.epa.gov/aqsweb/documents/codetables/aqi_breakpoints.html

