### PR TITLE
Add Rennes to the list of places

### DIFF
--- a/src/places.js
+++ b/src/places.js
@@ -283,6 +283,7 @@ module.exports = {
 	"alsace": [48.24905,7.52806],
 	"strasbourg": [48.5836,7.74806],
 	"grenoble": [45.2002,5.7222],
+	"rennes": [48.107,-1.659],
 
 //	Greece
 	"greece": [39,22],


### PR DESCRIPTION
Hi,

Leading up to the installation of about ten Luftdaten sensors in Rennes, France, the following PR adds the city to the list of places supported by the Feinstaub map. The default zoom of 11 works well.

Thanks for all your work!