### PR TITLE
Use median instead of mean

### DIFF
--- a/src/cell-info.vue
+++ b/src/cell-info.vue
@@ -6,20 +6,20 @@
 		a(href='#' id='map-info-off' onclick='document.getElementById("map-info-on").style.display="";document.getElementById("map-info-off").style.display="none";document.getElementById("map-info").style.display="none"; return false;' style='color:white; display:none;') Erklärung ausblenden
 	div(id='map-info' style='display:none')
 		p Die Kacheln werden aktuell nach dem Durchschnitt der PM10-Werte aller in der Zelle enthaltenen Sensoren eingefärbt. Siehe dazu die Skala unten links.
-		p Die Zahlen in der ersten Spalte entsprechen den Sensor-IDs. Die erste Zeile 'mean' enthält die jeweiligen Durchschnittswerte aller in der Zelle enthaltenen Sensoren.
+		p Die Zahlen in der ersten Spalte entsprechen den Sensor-IDs. Die erste Zeile 'median' enthält der jeweiligen Median aller in der Zelle enthaltenen Sensoren.
 		p Bitte beachten: Wir zeigen auf der Karte die Werte der letzten 5 Minuten an. Die von den jeweiligen Landesbehörden veröffentlichen Werte werden als 24-Stunden-Mittelwert angegeben. Dadurch können die Werte auf der Karte deutlich von diesen 24-Stunden-Mittelwerten abweichen.
 		p Durch einen Klick auf das Plus vor der Sensor-ID können 2 Grafiken eingeblendet werden. Die Grafik '24 h floating' zeigt den gleitenden 24-Stunden-Mittelwert für die letzten 7 Tage an. Aus technischen Gründen ist am Anfang eine Lücke von einem Tag, die Darstellung zeigt also eigentlich 8 Tage, der erste ist aber leer. Die zweite Grafik 'Last 24 hours' zeigt den Tagesverlauf für die letzten 24 Stunden.
 	h3 #Sensors {{cell.length}}
-	
+
 	table
 		tr
 			th Sensor ID
 			th PM10 µg/m³
 			th PM2.5 µg/m³
-		tr.mean
-			td mean
-			td {{mean.P1.toFixed(0)}}
-			td {{mean.P2.toFixed(0)}}
+		tr.median
+			td median
+			td {{median.P1.toFixed(0)}}
+			td {{median.P2.toFixed(0)}}
 		template(v-for="sensor in cell")
 			tr
 				td(style="text-align:left;")
@@ -34,6 +34,20 @@
 <script>
 import _ from 'lodash'
 
+function medianBy (rr, iterator) {
+	const r = _.map(rr, iterator)
+	const len = _.size(r)
+
+	if (len === 0) return null
+	if (len === 1) return r[0]
+
+	const sorted = _.sortBy(r, _.identity)
+	const idx = _.floor(len / 2)
+
+	if (len % 2 !== 0) return sorted[idx]
+	return (sorted[idx - 1] + sorted[idx]) / 2
+}
+
 export default {
 	data () {
 		return {
@@ -43,10 +57,10 @@ export default {
 		'cell': Array
 	},
 	computed: {
-		mean () {
+		median () {
 			return {
-				P1: _.meanBy(this.cell, (o) => o.o.data.P1),
-				P2: _.meanBy(this.cell, (o) => o.o.data.P2)
+				P1: medianBy(this.cell, (o) => o.o.data.P1),
+				P2: medianBy(this.cell, (o) => o.o.data.P2)
 			}
 		}
 	}

--- a/src/hexbin-layer.js
+++ b/src/hexbin-layer.js
@@ -6,6 +6,20 @@ import _ from 'lodash'
 
 d3.hexbin = d3Hexbin.hexbin
 
+function medianBy (rr, iterator) {
+	const r = _.map(rr, iterator)
+	const len = _.size(r)
+
+	if (len === 0) return null
+	if (len === 1) return r[0]
+
+	const sorted = _.sortBy(r, _.identity)
+	const idx = _.floor(len / 2)
+
+	if (len % 2 !== 0) return sorted[idx]
+	return (sorted[idx - 1] + sorted[idx]) / 2
+}
+
 L.HexbinLayer = L.Layer.extend({
 	_undef (a) { return typeof a === 'undefined' },
 	options: {
@@ -25,7 +39,7 @@ L.HexbinLayer = L.Layer.extend({
 			return d.latitude
 		},
 		value: function (d) {
-			return _.meanBy(d, (o) => o.o.data.P1)
+			return medianBy(d, o => o.o.data.P1)
 		}
 	},
 

--- a/src/style.styl
+++ b/src/style.styl
@@ -15,7 +15,7 @@ body, #content
 	background-color $clr-grey-50
 	display flex
 	justify-content column
-	
+
 .map
 	height 100vh
 	flex 1 0
@@ -47,7 +47,7 @@ body, #content
 		font-weight 300
 		border 1px solid $clr-grey-50
 		border-bottom 2px solid $clr-grey-50
-	.mean
+	.median
 		border-bottom 1px solid $clr-grey-50
 
 .leaflet-pane > svg .d3-overlay path
@@ -64,5 +64,5 @@ body, #content
 	font-weight 200
 	text-align right
 
-img.leaflet-tile 
-	filter  grayscale(85%) saturate(150%) hue-rotate(60deg) contrast(90%) brightness(110%) 
+img.leaflet-tile
+	filter  grayscale(85%) saturate(150%) hue-rotate(60deg) contrast(90%) brightness(110%)


### PR DESCRIPTION
Oftentimes, some cells on the map will become orange or red just because of one faulty device. This gives an unrealistic view of air quality in the region. Using median instead of mean is a more robust statistic and automatically filters out extreme values, while still representing the consensus of sensors in the region.